### PR TITLE
[SP-61034] - Fix streaming error order to return chunks before error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+gRPCMock is a protobuf plugin that generates mock gRPC server implementations from `.proto` files. It generates type-safe mock servers with fluent configuration API, supporting all RPC types (unary, server/client/bidirectional streaming).
+
+## Build & Test Commands
+
+```bash
+# Full test pipeline: builds plugin, generates protos, runs tests
+make test
+
+# Install the protoc plugin
+go install github.com/torqio/grpcmock/protoc-gen-grpcmock
+
+# Generate mocks from protos (in tests/ dir)
+cd tests && buf generate
+```
+
+**Required tools:** buf, protoc, gotestsum, Go 1.22+
+
+## Architecture
+
+### Core Components
+
+**pkg/mocker/** - Mock orchestration engine
+- `mocker.go` - Thread-safe call registration, matching, and tracking
+- `call.go` - `SingleExpectedCall` struct with DoAndReturn caching
+- `matchers.go` - Request matchers (`Any()`, `Eq()` with proto.Equal support)
+
+**protoc-gen-grpcmock/** - Code generation plugin
+- `main.go` - Plugin entry, template orchestration
+- `server_tmpl/mock_server.tmpl` - Main template generating `*_grpcmock.pb.go` files
+
+### Code Generation Flow
+
+```
+.proto → buf/protoc → protoc-gen-grpcmock → Go template → *_grpcmock.pb.go
+```
+
+Generated code per service:
+- `NewServiceMockServer()` constructor
+- Service implementation delegating to `Mocker.CallV2()`
+- Fluent configurers for `.On()`, `.Return()`, `.DoAndReturn()`
+
+### Mock Call Matching
+
+Mocker tries expected calls in registration order, checking `Matcher.Matches()` for each arg. First match wins → else DefaultCall → else `ErrNoMatchingCalls`.
+
+### API Versions
+
+- V1/V2: Basic `On().Return()`
+- V3: Adds `DoAndReturn`/`DefaultDoAndReturn` for dynamic responses
+
+## Key Patterns
+
+- **Thread safety:** All Mocker ops protected by RWMutex
+- **Call caching:** DoAndReturn results cached per-call for idempotency
+- **Streaming context:** Stream methods receive message + ServerStream for metadata access
+- **Parallel tests:** Integration tests use atomic counters, 50 concurrent subtests per scenario

--- a/protoc-gen-grpcmock/server_tmpl/mock_server.tmpl
+++ b/protoc-gen-grpcmock/server_tmpl/mock_server.tmpl
@@ -120,25 +120,24 @@ func (m *{{ .svc.GoName }}MockServer) {{ .method.GoName }}(stream {{ qualifiedId
         ret := expectedCall.Returns()
 		{{- if not (isStreamingServer .method) }}
         res, _ := ret[0].(*{{ qualifiedIdent .method.Output.GoIdent }})
-        err, _ = ret[1].(error)
+        retErr, _ := ret[1].(error)
 
-		if err != nil {
+		if err := stream.SendAndClose(res); err != nil {
 			return err
 		}
 
-		return stream.SendAndClose(res)
+		return retErr
 		{{- else }}
         results, _ := ret[0].([]*{{ qualifiedIdent .method.Output.GoIdent }})
-        err, _ = ret[1].(error)
-
-        if err != nil {
-            return err
-        }
+        retErr, _ := ret[1].(error)
 
         for _, res := range results {
             if err := stream.Send(res); err != nil {
                 return err
             }
+        }
+        if retErr != nil {
+            return retErr
         }
         found = true
 		{{- end }}
@@ -148,13 +147,13 @@ func (m *{{ .svc.GoName }}MockServer) {{ .method.GoName }}(stream {{ qualifiedId
     if defaultReturn != nil {
         ret := defaultReturn.Returns()
         res, _ := ret[0].(*{{ qualifiedIdent .method.Output.GoIdent }})
-        err, _ := ret[1].(error)
+        retErr, _ := ret[1].(error)
 
-        if err != nil {
+        if err := stream.SendAndClose(res); err != nil {
             return err
         }
 
-        return stream.SendAndClose(res)
+        return retErr
     }
 	err := mocker.ErrNoMatchingCalls{"{{ .method.GoName }}"}
 	m.mocker.LogError(err)
@@ -183,11 +182,7 @@ func (m *{{ .svc.GoName }}MockServer) {{ .method.GoName }}(req *{{ qualifiedIden
 
     ret := expectedCall.Returns()
 	results, _ := ret[0].([]*{{ qualifiedIdent .method.Output.GoIdent }})
-	err, _ = ret[1].(error)
-
-	if err != nil {
-		return err
-	}
+	retErr, _ := ret[1].(error)
 
 	for _, res := range results {
 		if err := stream.Send(res); err != nil {
@@ -195,7 +190,7 @@ func (m *{{ .svc.GoName }}MockServer) {{ .method.GoName }}(req *{{ qualifiedIden
 		}
 	}
 
-	return nil
+	return retErr
 }
 {{- end}}
 

--- a/tests/grpcmock_test.go
+++ b/tests/grpcmock_test.go
@@ -624,3 +624,96 @@ func TestDoAndReturnDefaultStreamResponse(t *testing.T) {
 		assert.True(t, errors.Is(err, io.EOF))
 	}
 }
+
+// TestStreamResponseWithError verifies server streaming returns chunks BEFORE error
+func TestStreamResponseWithError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testServer, err := NewExampleServiceMockServer()
+	require.NoError(t, err)
+	addr := startGrpcServer(t, testServer)
+
+	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	client := NewExampleServiceClient(conn)
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	expectedChunks := []*ExampleMethodResponse{
+		{Res: "chunk1"},
+		{Res: "chunk2"},
+		{Res: "chunk3"},
+	}
+	expectedErr := status.Error(codes.Internal, "test error after streaming")
+
+	testServer.Configure().ExampleStreamResponse().
+		On(&ExampleMethodRequest{Req: "stream-with-error"}, mocker.Any()).
+		Return(expectedChunks, expectedErr)
+
+	stream, err := client.ExampleStreamResponse(ctx, &ExampleMethodRequest{Req: "stream-with-error"})
+	require.NoError(t, err)
+
+	// Should receive all chunks first
+	for i, expected := range expectedChunks {
+		res, err := stream.Recv()
+		require.NoError(t, err, "chunk %d should be received before error", i)
+		assert.Equal(t, expected.GetRes(), res.GetRes())
+	}
+
+	// Final Recv should return the error
+	_, err = stream.Recv()
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+	assert.Contains(t, err.Error(), "test error after streaming")
+}
+
+// TestStreamRequestResponseWithError verifies bidi streaming returns chunks BEFORE error
+func TestStreamRequestResponseWithError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testServer, err := NewExampleServiceMockServer()
+	require.NoError(t, err)
+	addr := startGrpcServer(t, testServer)
+
+	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	client := NewExampleServiceClient(conn)
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	expectedChunks := []*ExampleMethodResponse{
+		{Res: "bidi-chunk1"},
+		{Res: "bidi-chunk2"},
+	}
+	expectedErr := status.Error(codes.Internal, "bidi error after streaming")
+
+	testServer.Configure().ExampleStreamRequestResponse().
+		On(&ExampleMethodRequest{Req: "bidi-with-error"}, mocker.Any()).
+		Return(expectedChunks, expectedErr)
+
+	stream, err := client.ExampleStreamRequestResponse(ctx)
+	require.NoError(t, err)
+
+	// Send request that matches configured mock
+	err = stream.Send(&ExampleMethodRequest{Req: "bidi-with-error"})
+	require.NoError(t, err)
+
+	// Should receive all chunks first
+	for i, expected := range expectedChunks {
+		res, err := stream.Recv()
+		require.NoError(t, err, "chunk %d should be received before error", i)
+		assert.Equal(t, expected.GetRes(), res.GetRes())
+	}
+
+	// Next Recv should return the error
+	_, err = stream.Recv()
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+	assert.Contains(t, err.Error(), "bidi error after streaming")
+}

--- a/tests/grpcmock_test.go
+++ b/tests/grpcmock_test.go
@@ -717,3 +717,88 @@ func TestStreamRequestResponseWithError(t *testing.T) {
 	assert.Equal(t, codes.Internal, status.Code(err))
 	assert.Contains(t, err.Error(), "bidi error after streaming")
 }
+
+// TestStreamRequestWithError verifies client streaming calls SendAndClose before returning error.
+// Note: gRPC protocol doesn't deliver response body when error status is returned,
+// so we can only verify the error is received. The fix ensures SendAndClose is called
+// (preventing potential panics/issues) even when an error will be returned.
+func TestStreamRequestWithError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testServer, err := NewExampleServiceMockServer()
+	require.NoError(t, err)
+	addr := startGrpcServer(t, testServer)
+
+	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	client := NewExampleServiceClient(conn)
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	expectedRes := &ExampleMethodResponse{Res: "response-before-error"}
+	expectedErr := status.Error(codes.Internal, "client stream error after response")
+
+	testServer.Configure().ExampleStreamRequest().
+		On(&ExampleMethodRequest{Req: "client-stream-error"}, mocker.Any()).
+		Return(expectedRes, expectedErr)
+
+	stream, err := client.ExampleStreamRequest(ctx)
+	require.NoError(t, err)
+
+	// Send request that matches configured mock
+	err = stream.Send(&ExampleMethodRequest{Req: "client-stream-error"})
+	require.NoError(t, err)
+
+	// CloseAndRecv returns the error (gRPC doesn't deliver response body on error status)
+	_, err = stream.CloseAndRecv()
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+	assert.Contains(t, err.Error(), "client stream error after response")
+}
+
+// TestStreamResponseWithErrorDefaultReturn verifies DefaultReturn also returns chunks BEFORE error
+func TestStreamResponseWithErrorDefaultReturn(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testServer, err := NewExampleServiceMockServer()
+	require.NoError(t, err)
+	addr := startGrpcServer(t, testServer)
+
+	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+
+	client := NewExampleServiceClient(conn)
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	expectedChunks := []*ExampleMethodResponse{
+		{Res: "default-chunk1"},
+		{Res: "default-chunk2"},
+	}
+	expectedErr := status.Error(codes.Internal, "default error after streaming")
+
+	// Configure DefaultReturn with error
+	testServer.Configure().ExampleStreamResponse().DefaultReturn(expectedChunks, expectedErr)
+
+	// Any request should trigger the default
+	stream, err := client.ExampleStreamResponse(ctx, &ExampleMethodRequest{Req: "any-request"})
+	require.NoError(t, err)
+
+	// Should receive all chunks first
+	for i, expected := range expectedChunks {
+		res, err := stream.Recv()
+		require.NoError(t, err, "chunk %d should be received before error", i)
+		assert.Equal(t, expected.GetRes(), res.GetRes())
+	}
+
+	// Final Recv should return the error
+	_, err = stream.Recv()
+	require.Error(t, err)
+	assert.Equal(t, codes.Internal, status.Code(err))
+	assert.Contains(t, err.Error(), "default error after streaming")
+}

--- a/tests/grpcmock_test.go
+++ b/tests/grpcmock_test.go
@@ -718,10 +718,11 @@ func TestStreamRequestResponseWithError(t *testing.T) {
 	assert.Contains(t, err.Error(), "bidi error after streaming")
 }
 
-// TestStreamRequestWithError verifies client streaming calls SendAndClose before returning error.
-// Note: gRPC protocol doesn't deliver response body when error status is returned,
-// so we can only verify the error is received. The fix ensures SendAndClose is called
-// (preventing potential panics/issues) even when an error will be returned.
+// TestStreamRequestWithError verifies client streaming calls SendAndClose before returning an error.
+// Note: gRPC protocol doesn't deliver the response body when an error status is returned,
+// so we can only verify that the error is received. This test ensures the mock server still
+// completes the client-stream lifecycle (including SendAndClose) before returning the configured
+// error, avoiding inconsistent stream state compared to real gRPC behavior.
 func TestStreamRequestWithError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Fix streaming mocks to return all response chunks before returning configured error
- Previously error was returned immediately, preventing clients from receiving streamed data
- Affects server streaming, bidi streaming, and client streaming code paths

Fixes SP-61034

🤖 Generated with [Claude Code](https://claude.com/claude-code)